### PR TITLE
feat(middleware): add connection, leeway, and token_verify_options support; refine skip_paths behavior

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,7 +36,7 @@ Metrics/PerceivedComplexity:
   Max: 12                  # Allow perceived complexity up to 15
 
 Metrics/ParameterLists:
-  Max: 6                   # Allow up to 6 method parameters
+  Max: 10                  # Allow up to 10 method parameters
 
 Metrics/ClassLength:
   Max: 150               # Relax class length a bit to accommodate documentation and small helpers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.1.2] - 2025-08-31
+
+### Added
+- Middleware: new `connection:` option to inject a Faraday::Connection, shared by Discovery and JWKS.
+- Middleware: new `leeway:` and `token_verify_options:` options, delegated to TokenDecoder.
+- README: documented usage of `connection`, leeway/options, and clarified `skip_paths` behavior.
+
+### Changed
+- Middleware: `skip_paths` semantics clarified — plain paths are exact-match only, use `/*` for prefix matching.
+- Middleware: TokenDecoder instances are now cached per JWKS fetch for performance improvement.
+- Internal: RuboCop style fixes (`HashExcept`, `HashTransformKeys`, long line splits).
+
+---
+
 ## [0.1.1] - 2025-08-24
 
 ### Changed

--- a/lib/verikloak/token_decoder.rb
+++ b/lib/verikloak/token_decoder.rb
@@ -30,11 +30,17 @@ module Verikloak
     # @param issuer   [String]      Expected `iss` value in the token.
     # @param audience [String]      Expected `aud` value in the token.
     # @param leeway   [Integer]     Clock skew tolerance in seconds (optional).
-    def initialize(jwks:, issuer:, audience:, leeway: DEFAULT_LEEWAY)
+    # @param options [Hash] Extra JWT verification options.
+    #   Mirrors ruby-jwt options (e.g., :leeway, :verify_iat, :verify_expiration, :verify_not_before, :algorithms).
+    #   NOTE: If both `leeway:` and `options[:leeway]` are provided, `options[:leeway]` takes precedence.
+    def initialize(jwks:, issuer:, audience:, leeway: DEFAULT_LEEWAY, options: {})
       @jwks     = jwks
       @issuer   = issuer
       @audience = audience
+      # Keep backward compatibility; can be overridden by options[:leeway]
       @leeway   = leeway
+      # Normalize and store verification options
+      @options  = symbolize_keys(options || {})
 
       # Build a kid-indexed hash for O(1) JWK lookup
       @jwk_by_kid = {}
@@ -42,6 +48,7 @@ module Verikloak
         kid_key = fetch_indifferent(j, 'kid')
         @jwk_by_kid[kid_key] = j if kid_key
       end
+      @options.freeze
     end
 
     # Decodes and verifies a JWT.
@@ -123,8 +130,7 @@ module Verikloak
     #
     # @return [Hash]
     def jwt_decode_options
-      {
-        # Specify allowed algorithms explicitly as an array to prevent header tampering
+      base = {
         algorithms: ['RS256'],
         iss: @issuer,
         verify_iss: true,
@@ -132,9 +138,14 @@ module Verikloak
         verify_aud: true,
         verify_iat: true,
         verify_expiration: true,
-        verify_not_before: true,
-        leeway: @leeway # allow clock skew tolerance
+        verify_not_before: true
       }
+      # options[:leeway] overrides top-level @leeway if provided
+      leeway = @options.key?(:leeway) ? @options[:leeway] : @leeway
+      merged = base.merge(leeway: leeway)
+      # Merge remaining options last (excluding :leeway which is already applied)
+      extra = @options.except(:leeway)
+      merged.merge(extra)
     end
 
     # Imports an OpenSSL::PKey::RSA public key from the given JWK.
@@ -241,6 +252,12 @@ module Verikloak
       else
         "JWT verification failed: #{error.message}"
       end
+    end
+
+    def symbolize_keys(hash)
+      return {} unless hash.is_a?(Hash)
+
+      hash.transform_keys(&:to_sym)
     end
   end
 end


### PR DESCRIPTION
# feat(middleware)
add connection, leeway, and token_verify_options support; refine skip_paths behavior

- Added `connection:` option to inject Faraday::Connection (shared by Discovery and JWKS)
- Added `leeway:` and `token_verify_options:` options, delegated to TokenDecoder
- Clarified skip_paths semantics:
  - plain paths are exact-match only
  - use /* for prefix matching
- Improved performance by caching TokenDecoder instances per JWKS fetch
- Updated README with usage examples and skip_paths clarification
- Updated CHANGELOG (v0.1.2)