### PR TITLE
chore(ci,gemspec): require Ruby >= 3.1 and harden CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           mkdir -p tmp artifacts
           # Run inside container; ensure pipeline returns non-zero on RuboCop failure
-          docker compose run --rm -u 0:0 dev bash -lc 'set -o pipefail; bundle exec rubocop | tee tmp/rubocop.log'
+          docker compose run --rm -u 0:0 dev bash -c 'set -o pipefail; bundle exec rubocop | tee tmp/rubocop.log'
           status=$?
           # Always collect the log for artifacts
           cp tmp/rubocop.log artifacts/ || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["**"]
@@ -26,8 +30,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
-      - name: Docker Compose Build (no cache)
-        run: docker compose build --no-cache --pull
+      - name: Docker Compose Build (pull latest base)
+        run: docker compose build --pull
 
       - name: Run RSpec with coverage and JUnit output
         run: |
@@ -81,9 +85,13 @@ jobs:
 
       - name: Run RuboCop
         run: |
-          mkdir -p tmp
-          docker compose run --rm -u 0:0 dev bash -c "bundle exec rubocop | tee tmp/rubocop.log"
-          test $? -eq 0 || (mkdir -p artifacts && cp tmp/rubocop.log artifacts/)
+          mkdir -p tmp artifacts
+          # Run inside container; ensure pipeline returns non-zero on RuboCop failure
+          docker compose run --rm -u 0:0 dev bash -lc 'set -o pipefail; bundle exec rubocop | tee tmp/rubocop.log'
+          status=$?
+          # Always collect the log for artifacts
+          cp tmp/rubocop.log artifacts/ || true
+          exit $status
 
       - name: Relax permissions for artifacts
         run: chmod -R a+rX tmp artifacts || true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   NewCops: enable
   Exclude:
     - 'spec/**/*'

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p lib/verikloak
 COPY lib/verikloak/version.rb lib/verikloak/version.rb
 COPY Gemfile Gemfile.lock ./
 
- # Faster, more reliable bundler installs
+# Faster, more reliable bundler installs
 ARG BUNDLE_FROZEN=1
 ENV BUNDLE_JOBS=4 BUNDLE_RETRY=3 BUNDLE_FROZEN=$BUNDLE_FROZEN
 RUN bundle install

--- a/verikloak.gemspec
+++ b/verikloak.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*.rb'] + %w[README.md LICENSE CHANGELOG.md]
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 3.0'
+  # Align with project/tooling and Dependabot's resolver
+  # Bundler versions Dependabot selects now require Ruby >= 3.1
+  spec.required_ruby_version = '>= 3.1'
 
   # Runtime dependencies
   spec.add_dependency 'faraday', '>= 2.0', '< 3.0'


### PR DESCRIPTION
gemspec: Update required_ruby_version to >= 3.1 for Bundler/Dependabot compatibility.
CI: Add concurrency to cancel duplicate runs on the same ref.
CI: Switch RSpec build to --pull to refresh the base image.
CI: Harden RuboCop step (pipefail, always collect logs, propagate exit code).