### PR TITLE
Release: v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.1.3] - 2025-09-15
+
+### Changed
+- Relax `jwt` runtime dependency to `>= 2.7, < 4.0` to allow jwt 3.x (PR #11).
+
+### Chore
+- Bump dev dependency `rubocop` to 1.80.2 (PR #13).
+- Bump dev dependency `rubocop-rspec` to 3.7.0 (PR #12).
+
+---
+
 ## [0.1.2] - 2025-08-31
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak (0.1.2)
+    verikloak (0.1.3)
       faraday (>= 2.0, < 3.0)
       json (~> 2.6)
       jwt (>= 2.7, < 4.0)

--- a/lib/verikloak/version.rb
+++ b/lib/verikloak/version.rb
@@ -2,5 +2,5 @@
 
 module Verikloak
   # Defines the current version of the Verikloak gem.
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
This PR prepares the v0.1.3 release.\n\nChanges\n- Change: Relax jwt runtime dependency to `>= 2.7, < 4.0` (PR #11).\n- Chore: Bump dev dependency rubocop to 1.80.2 (PR #13).\n- Chore: Bump dev dependency rubocop-rspec to 3.7.0 (PR #12).\n\nAlso updates: \n- lib/verikloak/version.rb -> 0.1.3\n- CHANGELOG.md -> adds 0.1.3 entry\n- Gemfile.lock path spec -> 0.1.3