### PR TITLE
Improve HTTP defaults and dynamic audience support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     verikloak (0.1.4)
       faraday (>= 2.0, < 3.0)
+      faraday-retry (>= 2.0, < 3.0)
       json (~> 2.6)
       jwt (>= 2.7, < 4.0)
 
@@ -27,8 +28,10 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
     hashdiff (1.2.0)
-    json (2.13.2)
+    json (2.14.1)
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)

--- a/README.md
+++ b/README.md
@@ -226,13 +226,13 @@ For a full list of error cases and detailed explanations, please see the [ERRORS
 | Key             | Required | Description                                 |
 | --------------- | -------- | ------------------------------------------- |
 | `discovery_url` | Yes   | Full URL to your realm's OIDC discovery doc |
-| `audience`      | Yes   | Your client ID (checked against `aud`)      |
+| `audience`      | Yes   | Your client ID (checked against `aud`). Accepts a String or callable returning a String/Array per request. |
 | `skip_paths`    | No       | Array of paths or wildcards to skip authentication, e.g. `['/', '/health', '/public/*']`. **Note:** Regex patterns are not supported. |
 | `discovery`     | No       | Inject custom Discovery instance (advanced/testing) |
 | `jwks_cache`    | No       | Inject custom JwksCache instance (advanced/testing) |
 | `leeway`       | No       | Clock skew tolerance (seconds) applied during JWT verification. Defaults to `TokenDecoder::DEFAULT_LEEWAY`. |
 | `token_verify_options` | No | Hash of advanced JWT verification options passed through to TokenDecoder. For example: `{ verify_iat: false, leeway: 10, algorithms: ["RS256"] }`. If both `leeway:` and `token_verify_options[:leeway]` are set, the latter takes precedence. |
-| `connection`   | No       | Inject a Faraday::Connection used for both Discovery and JWKs fetches. Allows unified timeout, retry, and headers. |
+| `connection`   | No       | Inject a Faraday::Connection used for both Discovery and JWKs fetches. Defaults to a safe connection with timeouts and retries. |
 
 #### Option: `skip_paths`
 
@@ -254,10 +254,25 @@ Paths **not matched** by any `skip_paths` entry will require a valid JWT.
 **Note:** Regex patterns are not supported. Only literal paths and `*` wildcards are allowed.  
 Internally, `*` expands to match nested paths, so patterns like `/rails/*` are valid. This differs from regex — for example, `'/rails'` alone matches only `/rails`, while `'/rails/*'` covers both `/rails` and deeper subpaths.
 
+#### Option: `audience`
+
+The `audience` option may be either a static String or any callable object (Proc, lambda, object responding to `#call`). When a callable is provided it receives the Rack `env` and can return a different audience for each request. This is useful when a single gateway serves multiple downstream clients:
+
+```ruby
+Verikloak::Middleware.new(app,
+  discovery_url: ENV['DISCOVERY_URL'],
+  audience: ->(env) {
+    env['PATH_INFO'].start_with?('/admin') ? 'admin-client-id' : 'public-client-id'
+  }
+)
+```
+
+The callable may also return an Array of audiences when a route is valid for multiple clients.
+
 #### Customizing Faraday for Discovery and JWKs
 
-Both `Discovery` and `JwksCache` accept a `Faraday::Connection`.  
-This allows you to configure timeouts, retries, logging, and shared headers:
+Both `Discovery` and `JwksCache` accept a `Faraday::Connection`.
+Verikloak ships with a conservative default connection (5s timeout, 2s open timeout, retries for transient errors). If you need additional middleware such as logging, metrics, or custom adapters you can still inject your own connection:
 
 ```ruby
 connection = Faraday.new(request: { timeout: 5 }) do |f|

--- a/lib/verikloak.rb
+++ b/lib/verikloak.rb
@@ -5,6 +5,7 @@
 # by simply requiring 'verikloak'.
 require 'verikloak/version'
 require 'verikloak/errors'
+require 'verikloak/http'
 require 'verikloak/discovery'
 require 'verikloak/jwks_cache'
 require 'verikloak/token_decoder'

--- a/lib/verikloak/discovery.rb
+++ b/lib/verikloak/discovery.rb
@@ -4,6 +4,8 @@ require 'faraday'
 require 'json'
 require 'uri'
 
+require 'verikloak/http'
+
 module Verikloak
   # Fetches and caches the OpenID Connect Discovery document.
   #
@@ -39,10 +41,10 @@ module Verikloak
     REQUIRED_FIELDS = %w[jwks_uri issuer].freeze
 
     # @param discovery_url [String] The full URL to the `.well-known/openid-configuration`.
-    # @param connection [Faraday::Connection] Optional Faraday client (for DI/tests). Defaults to `Faraday.new`.
+    # @param connection [Faraday::Connection] Optional Faraday client (for DI/tests).
     # @param cache_ttl [Integer] Cache TTL in seconds (default: 3600).
     # @raise [DiscoveryError] when `discovery_url` is not a valid HTTP(S) URL
-    def initialize(discovery_url:, connection: Faraday.new, cache_ttl: 3600)
+    def initialize(discovery_url:, connection: Verikloak::HTTP.default_connection, cache_ttl: 3600)
       unless discovery_url.is_a?(String) && discovery_url.strip.match?(%r{^https?://})
         raise DiscoveryError.new('Invalid discovery URL: must be a non-empty HTTP(S) URL',
                                  code: 'invalid_discovery_url')

--- a/lib/verikloak/http.rb
+++ b/lib/verikloak/http.rb
@@ -6,9 +6,13 @@ require 'faraday/retry'
 module Verikloak
   # Internal HTTP helpers shared across components.
   module HTTP
+    # Default request timeout (seconds) for outbound discovery/JWKs calls.
     DEFAULT_TIMEOUT = 5
+    # Default open/read timeout (seconds) before establishing the HTTP connection.
     DEFAULT_OPEN_TIMEOUT = 2
 
+    # Retry middleware configuration used for idempotent GET requests.
+    # Retries on 429/5xx with exponential backoff and jitter.
     RETRY_OPTIONS = {
       max: 2,
       interval: 0.1,

--- a/lib/verikloak/http.rb
+++ b/lib/verikloak/http.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'faraday/retry'
+
+module Verikloak
+  # Internal HTTP helpers shared across components.
+  module HTTP
+    DEFAULT_TIMEOUT = 5
+    DEFAULT_OPEN_TIMEOUT = 2
+
+    RETRY_OPTIONS = {
+      max: 2,
+      interval: 0.1,
+      interval_randomness: 0.2,
+      backoff_factor: 2,
+      methods: %i[get],
+      retry_statuses: [429, 500, 502, 503, 504]
+    }.freeze
+
+    # Builds a Faraday connection with conservative defaults suitable for
+    # network-bound operations (discovery and JWKs fetching).
+    #
+    # @return [Faraday::Connection]
+    def self.default_connection
+      Faraday.new do |f|
+        f.request :retry, RETRY_OPTIONS
+        f.options.timeout = DEFAULT_TIMEOUT
+        f.options.open_timeout = DEFAULT_OPEN_TIMEOUT
+        f.adapter Faraday.default_adapter
+      end
+    end
+  end
+end

--- a/lib/verikloak/middleware.rb
+++ b/lib/verikloak/middleware.rb
@@ -5,6 +5,8 @@ require 'json'
 require 'set'
 require 'faraday'
 
+require 'verikloak/http'
+
 module Verikloak
   # @api private
   #
@@ -106,12 +108,12 @@ module Verikloak
 
     # Returns a cached TokenDecoder instance for current inputs.
     # Cache key uses issuer, audience, leeway, token_verify_options, and JWKs fetched_at timestamp.
-    def decoder_for
+    def decoder_for(audience)
       keys = @jwks_cache.cached
       fetched_at = @jwks_cache.respond_to?(:fetched_at) ? @jwks_cache.fetched_at : nil
       cache_key = [
         @issuer,
-        @audience,
+        audience,
         @leeway,
         @token_verify_options,
         fetched_at
@@ -120,7 +122,7 @@ module Verikloak
         @decoder_cache[cache_key] ||= TokenDecoder.new(
           jwks: keys,
           issuer: @issuer,
-          audience: @audience,
+          audience: audience,
           leeway: @leeway,
           options: @token_verify_options
         )
@@ -142,14 +144,16 @@ module Verikloak
     # @param token [String]
     # @return [Hash] decoded JWT claims
     # @raise [Verikloak::Error] bubbles up verification/fetch errors for centralized handling
-    def decode_token(token)
+    def decode_token(env, token)
       ensure_jwks_cache!
       if @jwks_cache.cached.nil? || @jwks_cache.cached.empty?
         raise MiddlewareError.new('JWKs cache is empty, cannot verify token', code: 'jwks_cache_miss')
       end
 
+      audience = resolve_audience(env)
+
       # First attempt
-      decoder = decoder_for
+      decoder = decoder_for(audience)
 
       begin
         decoder.decode!(token)
@@ -160,9 +164,42 @@ module Verikloak
         refresh_jwks!
 
         # Rebuild decoder with refreshed keys and try once more.
-        decoder = decoder_for
+        decoder = decoder_for(audience)
         decoder.decode!(token)
       end
+    end
+
+    # Resolves the expected audience for the current request.
+    #
+    # @param env [Hash] Rack environment.
+    # @return [String, Array<String>] The expected audience value.
+    # @raise [MiddlewareError] when the resolved audience is blank.
+    def resolve_audience(env)
+      source = @audience_source
+      value = if source.respond_to?(:call)
+                callable = source
+                arity = callable.respond_to?(:arity) ? callable.arity : callable.method(:call).arity
+                arity.zero? ? callable.call : callable.call(env)
+              else
+                source
+              end
+
+      if value.nil?
+        raise MiddlewareError.new('Audience is blank for the request', code: 'invalid_audience')
+      end
+
+      if value.is_a?(Array)
+        raise MiddlewareError.new('Audience is blank for the request', code: 'invalid_audience') if value.empty?
+        return value
+      end
+
+      normalized = value.is_a?(Symbol) ? value.to_s : value
+      normalized = normalized.to_s if !normalized.is_a?(String)
+      if normalized.empty?
+        raise MiddlewareError.new('Audience is blank for the request', code: 'invalid_audience')
+      end
+
+      normalized
     end
 
     # Ensures that discovery metadata and JWKs cache are initialized and up-to-date.
@@ -280,11 +317,13 @@ module Verikloak
 
     # @param app [#call] downstream Rack app
     # @param discovery_url [String] OIDC discovery endpoint URL
-    # @param audience [String] expected `aud` claim
+    # @param audience [String, #call] Expected `aud` claim. When a callable is provided it
+    #   receives the Rack env and may return a String or Array of audiences.
     # @param skip_paths [Array<String>] literal paths or wildcard patterns to bypass auth
     # @param discovery [Discovery, nil] custom discovery instance (for DI/tests)
     # @param jwks_cache [JwksCache, nil] custom JWKs cache instance (for DI/tests)
-    # @param connection [Faraday::Connection, nil] Optional injected Faraday connection (defaults to Faraday.new)
+    # @param connection [Faraday::Connection, nil] Optional injected Faraday connection
+    #   (defaults to {Verikloak::HTTP.default_connection})
     # @param leeway [Integer] Clock skew tolerance in seconds for token verification (delegated to TokenDecoder)
     # @param token_verify_options [Hash] Additional JWT verification options passed through
     #   to TokenDecoder.
@@ -298,11 +337,11 @@ module Verikloak
                    connection: nil,
                    leeway: Verikloak::TokenDecoder::DEFAULT_LEEWAY,
                    token_verify_options: {})
-      @app           = app
-      @audience      = audience
-      @discovery     = discovery || Discovery.new(discovery_url: discovery_url)
-      @jwks_cache    = jwks_cache
-      @connection    = connection || Faraday.new
+      @app             = app
+      @connection      = connection || Verikloak::HTTP.default_connection
+      @audience_source = audience
+      @discovery       = discovery || Discovery.new(discovery_url: discovery_url, connection: @connection)
+      @jwks_cache      = jwks_cache
       @leeway        = leeway
       @token_verify_options = token_verify_options || {}
       @issuer        = nil
@@ -344,7 +383,7 @@ module Verikloak
     # @param token [String]
     # @return [Array(Integer, Hash, Array<String>)] Rack response triple
     def handle_request(env, token)
-      claims = decode_token(token)
+      claims = decode_token(env, token)
       env['verikloak.token'] = token
       env['verikloak.user']  = claims
       @app.call(env)

--- a/spec/verikloak/http_spec.rb
+++ b/spec/verikloak/http_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "verikloak/http"
+
+RSpec.describe Verikloak::HTTP do
+  describe ".default_connection" do
+    it "returns a Faraday connection with retry middleware and timeouts" do
+      conn = described_class.default_connection
+
+      expect(conn).to be_a(Faraday::Connection)
+      expect(conn.builder.handlers).to include(Faraday::Retry::Middleware)
+      expect(conn.builder.adapter).to eq(Faraday::Adapter::NetHttp)
+      expect(conn.options.timeout).to eq(described_class::DEFAULT_TIMEOUT)
+      expect(conn.options.open_timeout).to eq(described_class::DEFAULT_OPEN_TIMEOUT)
+    end
+
+    it "configures retry middleware with the constant options" do
+      fake_conn = instance_double(Faraday::Connection)
+      request_options = double("RequestOptions")
+
+      expect(fake_conn).to receive(:request).with(:retry, described_class::RETRY_OPTIONS)
+      expect(fake_conn).to receive(:options).twice.and_return(request_options)
+      expect(request_options).to receive(:timeout=).with(described_class::DEFAULT_TIMEOUT)
+      expect(request_options).to receive(:open_timeout=).with(described_class::DEFAULT_OPEN_TIMEOUT)
+      expect(fake_conn).to receive(:adapter).with(Faraday.default_adapter)
+
+      expect(Faraday).to receive(:new).and_yield(fake_conn).and_return(fake_conn)
+
+      expect(described_class.default_connection).to eq(fake_conn)
+    end
+  end
+end

--- a/spec/verikloak/jwks_cache_spec.rb
+++ b/spec/verikloak/jwks_cache_spec.rb
@@ -258,15 +258,15 @@ RSpec.describe Verikloak::JwksCache do
         headers: { "Cache-Control" => "max-age=120" }
       )
 
-    # Revalidation at t0 + 10s
-    allow(Time).to receive(:now).and_return(t0 + 10)
+    # Revalidation once TTL has expired (t0 + 61s)
+    allow(Time).to receive(:now).and_return(t0 + 61)
     cache.fetch!
 
-    # After revalidation, TTL is 120 from the new fetched_at (t0 + 10)
-    allow(Time).to receive(:now).and_return(t0 + 10 + 119)
+    # After revalidation, TTL is 120 from the new fetched_at (t0 + 61)
+    allow(Time).to receive(:now).and_return(t0 + 61 + 119)
     expect(cache.stale?).to eq(false)
 
-    allow(Time).to receive(:now).and_return(t0 + 10 + 121)
+    allow(Time).to receive(:now).and_return(t0 + 61 + 121)
     expect(cache.stale?).to eq(true)
   end
 

--- a/verikloak.gemspec
+++ b/verikloak.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency 'faraday', '>= 2.0', '< 3.0'
+  spec.add_dependency 'faraday-retry', '>= 2.0', '< 3.0'
   spec.add_dependency 'json', '~> 2.6'
   spec.add_dependency 'jwt', '>= 2.7', '< 4.0'
 


### PR DESCRIPTION
## Summary
- add a shared HTTP helper that applies conservative Faraday timeouts and retries, and wire it into discovery, middleware, and JWKs cache
- allow the middleware to resolve `audience` dynamically per request while ensuring blank audiences are rejected early
- avoid remote JWK fetches while cache TTL is valid and document/test the new behaviours