### PR TITLE
Fixed SSRF protection bypass for development mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.1] - 2026-02-15
+
+### Fixed
+- **SSRF protection bypass for development mode**: `allow_http: true` now also skips private IP validation in both `JwksCache` (initial `jwks_uri` resolution) and `Discovery` (redirect target resolution). Previously, even with `allow_http: true`, connections to Keycloak on private/loopback IPs (e.g. `127.0.0.1`, `10.x.x.x`, `192.168.x.x`) were blocked by SSRF protection, making local development impossible.
+- **Inconsistent SSRF behaviour**: `Discovery#fetch!` did not validate the initial discovery URL against private IPs (only redirect targets), while `JwksCache` unconditionally blocked private IPs at initialisation. Both now consistently skip private IP checks when `allow_http: true`.
+
+---
+
 ## [1.0.0] - 2026-02-15
 
 ### Security

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak (1.0.0)
+    verikloak (1.0.1)
       faraday (>= 2.14.1, < 3.0)
       faraday-retry (>= 2.4.0, < 3.0)
       json (~> 2.6)
@@ -100,6 +100,7 @@ PLATFORMS
   aarch64-linux
   aarch64-linux-musl
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
   x86_64-linux-musl
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Verikloak is a plug-and-play solution for Ruby (especially Rails API) apps that 
 - Rails/Rack middleware support
 - Faraday-based customizable HTTP layer
 - HTTPS enforcement for Discovery and JWKs endpoints (with `allow_http:` escape hatch for development)
-- SSRF protection — discovery redirect targets **and** `jwks_uri` values validated against private IP ranges (including IPv4-mapped IPv6 normalisation)
+- SSRF protection — discovery redirect targets **and** `jwks_uri` values validated against private IP ranges (including IPv4-mapped IPv6 normalisation); automatically bypassed with `allow_http: true` for local development
 - HTTPS redirect enforcement — redirect targets are scheme-checked to prevent HTTPS→HTTP downgrade
 - JWT size limit (8 KB) to mitigate denial-of-service via oversized tokens
 - Header injection prevention in `WWW-Authenticate` responses
@@ -225,7 +225,7 @@ For a full list of error cases and detailed explanations, please see the [ERRORS
 | `discovery_redirect_error` | 503 Service Unavailable   | Discovery redirect error: missing/invalid Location header, redirect target resolves to a private IP (SSRF protection), redirect uses non-HTTPS scheme, or unsupported scheme |
 | `insecure_discovery_url`   | 503 Service Unavailable   | Discovery URL uses `http://` and `allow_http: true` is not set                               |
 | `insecure_jwks_uri`        | 503 Service Unavailable   | JWKs URI uses `http://` and `allow_http: true` is not set                                    |
-| `jwks_ssrf_blocked`        | 503 Service Unavailable   | JWKs URI hostname resolves to a private/loopback IP address (SSRF protection)                |
+| `jwks_ssrf_blocked`        | 503 Service Unavailable   | JWKs URI hostname resolves to a private/loopback IP address (SSRF protection; bypassed when `allow_http: true`) |
 | `internal_server_error`    | 500 Internal Server Error | Unexpected internal error (catch-all)                                                        |
 
 > **Note:** The `decode_with_public_key` method ensures consistent error codes for all JWT verification failures.  
@@ -250,7 +250,7 @@ For a full list of error cases and detailed explanations, please see the [ERRORS
 | `user_env_key`  | No       | Rack env key for decoded claims. Defaults to `verikloak.user`. |
 | `realm`         | No       | Value used in the `WWW-Authenticate` header. Defaults to `verikloak`. |
 | `logger`        | No       | Logger for unexpected internal failures (responds to `error`, optionally `debug`). |
-| `allow_http`    | No       | When `false` (default), `Discovery` and `JwksCache` reject plain `http://` URLs. Set `true` **only** for local development against a non-TLS Keycloak instance. |
+| `allow_http`    | No       | When `false` (default), `Discovery` and `JwksCache` reject plain `http://` URLs and block private/loopback IPs (SSRF protection). Set `true` **only** for local development against a non-TLS Keycloak instance — this also bypasses private IP checks so that Keycloak on `localhost` or LAN addresses works out of the box. |
 
 #### Option: `skip_paths`
 

--- a/lib/verikloak/discovery.rb
+++ b/lib/verikloak/discovery.rb
@@ -267,10 +267,13 @@ module Verikloak
 
     # Validates that the redirect target does not resolve to a private/internal IP.
     # IPv4-mapped IPv6 addresses are normalised before comparison.
+    # Skipped when `@allow_http` is true (development mode).
     # @api private
     # @param uri [URI] Parsed redirect target
     # @raise [DiscoveryError]
     def validate_redirect_not_private!(uri)
+      return if @allow_http
+
       host = uri.host
       return unless host
 

--- a/lib/verikloak/jwks_cache.rb
+++ b/lib/verikloak/jwks_cache.rb
@@ -61,7 +61,7 @@ module Verikloak
         )
       end
 
-      validate_not_private!(clean_jwks_uri)
+      validate_not_private!(clean_jwks_uri) unless allow_http
 
       @jwks_uri    = clean_jwks_uri
       @connection  = connection || Verikloak::HTTP.default_connection

--- a/lib/verikloak/version.rb
+++ b/lib/verikloak/version.rb
@@ -2,5 +2,5 @@
 
 module Verikloak
   # Defines the current version of the Verikloak gem.
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/spec/verikloak/discovery_spec.rb
+++ b/spec/verikloak/discovery_spec.rb
@@ -404,4 +404,81 @@ RSpec.describe Verikloak::Discovery do
       }
     end
   end
+
+  # --- SSRF redirect bypass with allow_http: true ---
+  describe "SSRF redirect bypass with allow_http: true" do
+    it "allows redirect to private IP (192.168.x.x) when allow_http: true" do
+      stub_request(:get, "http://dev.local/.well-known/openid-configuration").to_return(
+        status: 302,
+        headers: { "Location" => "http://keycloak.local/config" }
+      )
+      stub_request(:get, "http://keycloak.local/config").to_return(
+        status: 200,
+        body: { jwks_uri: "http://keycloak.local/jwks", issuer: "http://keycloak.local/" }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+      allow(Resolv).to receive(:getaddresses).with("keycloak.local").and_return(["192.168.1.50"])
+
+      discovery = described_class.new(
+        discovery_url: "http://dev.local/.well-known/openid-configuration",
+        allow_http: true
+      )
+      json = discovery.fetch!
+      expect(json["issuer"]).to eq("http://keycloak.local/")
+    end
+
+    it "allows redirect to loopback (127.0.0.1) when allow_http: true" do
+      stub_request(:get, "http://dev.local/.well-known/openid-configuration").to_return(
+        status: 302,
+        headers: { "Location" => "http://localhost/config" }
+      )
+      stub_request(:get, "http://localhost/config").to_return(
+        status: 200,
+        body: { jwks_uri: "http://localhost/jwks", issuer: "http://localhost/" }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+      allow(Resolv).to receive(:getaddresses).with("localhost").and_return(["127.0.0.1"])
+
+      discovery = described_class.new(
+        discovery_url: "http://dev.local/.well-known/openid-configuration",
+        allow_http: true
+      )
+      json = discovery.fetch!
+      expect(json["issuer"]).to eq("http://localhost/")
+    end
+
+    it "allows redirect to 10.x.x.x when allow_http: true" do
+      stub_request(:get, "http://dev.local/.well-known/openid-configuration").to_return(
+        status: 302,
+        headers: { "Location" => "http://internal.local/config" }
+      )
+      stub_request(:get, "http://internal.local/config").to_return(
+        status: 200,
+        body: { jwks_uri: "http://internal.local/jwks", issuer: "http://internal.local/" }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+      allow(Resolv).to receive(:getaddresses).with("internal.local").and_return(["10.0.0.5"])
+
+      discovery = described_class.new(
+        discovery_url: "http://dev.local/.well-known/openid-configuration",
+        allow_http: true
+      )
+      json = discovery.fetch!
+      expect(json["issuer"]).to eq("http://internal.local/")
+    end
+
+    it "still blocks redirect to private IP when allow_http: false (default)" do
+      stub_request(:get, discovery_url).to_return(
+        status: 302,
+        headers: { "Location" => "https://internal.example.com/config" }
+      )
+      allow(Resolv).to receive(:getaddresses).with("internal.example.com").and_return(["10.0.0.1"])
+
+      discovery = described_class.new(discovery_url: discovery_url)
+      expect { discovery.fetch! }.to raise_error(Verikloak::DiscoveryError) { |e|
+        expect(e.code).to eq("discovery_redirect_error")
+        expect(e.message).to match(/private.*internal/i)
+      }
+    end
+  end
 end

--- a/spec/verikloak/jwks_cache_spec.rb
+++ b/spec/verikloak/jwks_cache_spec.rb
@@ -375,4 +375,45 @@ RSpec.describe Verikloak::JwksCache do
     cache.fetch!
     stubs.verify_stubbed_calls
   end
+
+  # --- SSRF protection bypass with allow_http: true ---
+  describe "SSRF bypass with allow_http: true" do
+    it "allows jwks_uri resolving to 127.0.0.1 when allow_http: true" do
+      allow(Resolv).to receive(:getaddresses).with("localhost").and_return(["127.0.0.1"])
+
+      cache = described_class.new(jwks_uri: "http://localhost/jwks", allow_http: true)
+      expect(cache.instance_variable_get(:@jwks_uri)).to eq("http://localhost/jwks")
+    end
+
+    it "allows jwks_uri resolving to 10.x.x.x when allow_http: true" do
+      allow(Resolv).to receive(:getaddresses).with("keycloak.local").and_return(["10.0.0.5"])
+
+      cache = described_class.new(jwks_uri: "http://keycloak.local/jwks", allow_http: true)
+      expect(cache.instance_variable_get(:@jwks_uri)).to eq("http://keycloak.local/jwks")
+    end
+
+    it "allows jwks_uri resolving to 192.168.x.x when allow_http: true" do
+      allow(Resolv).to receive(:getaddresses).with("keycloak.home").and_return(["192.168.1.50"])
+
+      cache = described_class.new(jwks_uri: "http://keycloak.home/jwks", allow_http: true)
+      expect(cache.instance_variable_get(:@jwks_uri)).to eq("http://keycloak.home/jwks")
+    end
+
+    it "allows jwks_uri resolving to ::1 when allow_http: true" do
+      allow(Resolv).to receive(:getaddresses).with("ipv6loopback.local").and_return(["::1"])
+
+      cache = described_class.new(jwks_uri: "http://ipv6loopback.local/jwks", allow_http: true)
+      expect(cache.instance_variable_get(:@jwks_uri)).to eq("http://ipv6loopback.local/jwks")
+    end
+
+    it "still blocks private IPs when allow_http: false (default)" do
+      allow(Resolv).to receive(:getaddresses).with("localhost").and_return(["127.0.0.1"])
+
+      expect {
+        described_class.new(jwks_uri: "https://localhost/jwks")
+      }.to raise_error(Verikloak::JwksCacheError) { |e|
+        expect(e.code).to eq("jwks_ssrf_blocked")
+      }
+    end
+  end
 end

--- a/spec/verikloak/security_hardening_spec.rb
+++ b/spec/verikloak/security_hardening_spec.rb
@@ -381,4 +381,102 @@ RSpec.describe "Verikloak::Middleware security hardening" do
       }
     end
   end
+
+  describe "JwksCache SSRF bypass with allow_http: true" do
+    it "allows jwks_uri resolving to 127.0.0.1 when allow_http: true" do
+      allow(Resolv).to receive(:getaddresses).with("localhost").and_return(["127.0.0.1"])
+
+      cache = Verikloak::JwksCache.new(jwks_uri: "http://localhost/jwks", allow_http: true)
+      expect(cache.instance_variable_get(:@jwks_uri)).to eq("http://localhost/jwks")
+    end
+
+    it "allows jwks_uri resolving to 10.x.x.x when allow_http: true" do
+      allow(Resolv).to receive(:getaddresses).with("keycloak.local").and_return(["10.0.0.5"])
+
+      cache = Verikloak::JwksCache.new(jwks_uri: "http://keycloak.local/jwks", allow_http: true)
+      expect(cache.instance_variable_get(:@jwks_uri)).to eq("http://keycloak.local/jwks")
+    end
+
+    it "allows jwks_uri resolving to 192.168.x.x when allow_http: true" do
+      allow(Resolv).to receive(:getaddresses).with("keycloak.home").and_return(["192.168.1.50"])
+
+      cache = Verikloak::JwksCache.new(jwks_uri: "http://keycloak.home/jwks", allow_http: true)
+      expect(cache.instance_variable_get(:@jwks_uri)).to eq("http://keycloak.home/jwks")
+    end
+
+    it "allows jwks_uri resolving to ::1 when allow_http: true" do
+      allow(Resolv).to receive(:getaddresses).with("ipv6loopback.local").and_return(["::1"])
+
+      cache = Verikloak::JwksCache.new(jwks_uri: "http://ipv6loopback.local/jwks", allow_http: true)
+      expect(cache.instance_variable_get(:@jwks_uri)).to eq("http://ipv6loopback.local/jwks")
+    end
+
+    it "still blocks private IPs when allow_http: false (default)" do
+      allow(Resolv).to receive(:getaddresses).with("localhost").and_return(["127.0.0.1"])
+
+      expect {
+        Verikloak::JwksCache.new(jwks_uri: "https://localhost/jwks")
+      }.to raise_error(Verikloak::JwksCacheError) { |e|
+        expect(e.code).to eq("jwks_ssrf_blocked")
+      }
+    end
+  end
+
+  describe "Discovery SSRF redirect bypass with allow_http: true" do
+    it "allows redirect to private IP when allow_http: true" do
+      stub_request(:get, "http://dev.local/.well-known/openid-configuration").to_return(
+        status: 302,
+        headers: { "Location" => "http://keycloak.local/config" }
+      )
+      stub_request(:get, "http://keycloak.local/config").to_return(
+        status: 200,
+        body: { jwks_uri: "http://keycloak.local/jwks", issuer: "http://keycloak.local/" }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+      allow(Resolv).to receive(:getaddresses).with("keycloak.local").and_return(["192.168.1.50"])
+
+      discovery = Verikloak::Discovery.new(
+        discovery_url: "http://dev.local/.well-known/openid-configuration",
+        allow_http: true
+      )
+      json = discovery.fetch!
+      expect(json["issuer"]).to eq("http://keycloak.local/")
+    end
+
+    it "allows redirect to loopback when allow_http: true" do
+      stub_request(:get, "http://dev.local/.well-known/openid-configuration").to_return(
+        status: 302,
+        headers: { "Location" => "http://localhost/config" }
+      )
+      stub_request(:get, "http://localhost/config").to_return(
+        status: 200,
+        body: { jwks_uri: "http://localhost/jwks", issuer: "http://localhost/" }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+      allow(Resolv).to receive(:getaddresses).with("localhost").and_return(["127.0.0.1"])
+
+      discovery = Verikloak::Discovery.new(
+        discovery_url: "http://dev.local/.well-known/openid-configuration",
+        allow_http: true
+      )
+      json = discovery.fetch!
+      expect(json["issuer"]).to eq("http://localhost/")
+    end
+
+    it "still blocks redirect to private IP when allow_http: false" do
+      stub_request(:get, "https://example.com/.well-known/openid-configuration").to_return(
+        status: 302,
+        headers: { "Location" => "https://internal.example.com/config" }
+      )
+      allow(Resolv).to receive(:getaddresses).with("internal.example.com").and_return(["10.0.0.1"])
+
+      discovery = Verikloak::Discovery.new(
+        discovery_url: "https://example.com/.well-known/openid-configuration"
+      )
+      expect { discovery.fetch! }.to raise_error(Verikloak::DiscoveryError) { |e|
+        expect(e.code).to eq("discovery_redirect_error")
+        expect(e.message).to match(/private.*internal/i)
+      }
+    end
+  end
 end


### PR DESCRIPTION
### Fixed
- **SSRF protection bypass for development mode**: `allow_http: true` now also skips private IP validation in both `JwksCache` (initial `jwks_uri` resolution) and `Discovery` (redirect target resolution). Previously, even with `allow_http: true`, connections to Keycloak on private/loopback IPs (e.g. `127.0.0.1`, `10.x.x.x`, `192.168.x.x`) were blocked by SSRF protection, making local development impossible.
- **Inconsistent SSRF behaviour**: `Discovery#fetch!` did not validate the initial discovery URL against private IPs (only redirect targets), while `JwksCache` unconditionally blocked private IPs at initialisation. Both now consistently skip private IP checks when `allow_http: true`.