### PR TITLE
Fix iat leeway validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2] - 2026-05-09
 
 ### Fixed
-- **`iat` claim now honors `leeway`** (`TokenDecoder`): On ruby-jwt 3.x the
-  built-in `Claims::IssuedAt` validator ignores the `leeway` option and
-  raises `JWT::InvalidIatError` whenever `iat` is even a fraction of a
-  second in the future. In typical OIDC deployments the IdP (e.g. Keycloak)
-  and the Resource Server run on different hosts/containers, so `iat` is
-  routinely a few hundred milliseconds to a few seconds ahead of the
-  Resource Server's clock and the previously-effective leeway of `0` for
-  `iat` produced spurious 401s. `TokenDecoder` now disables ruby-jwt's
-  built-in `iat` check and performs its own `iat` validation that applies
-  the configured `leeway` consistently with `exp` and `nbf`. Behaviour
-  for tokens with `iat` further in the future than `leeway` is unchanged
-  (still rejected with `invalid_token`). Pass
-  `options: { verify_iat: false }` to skip the check entirely.
+- **`iat` claim now honors `leeway`** (`TokenDecoder`): On ruby-jwt 3.x the built-in `Claims::IssuedAt` validator ignores the `leeway` option and raises `JWT::InvalidIatError` whenever `iat` is even a fraction of a second in the future. In typical OIDC deployments the IdP (e.g. Keycloak) and the Resource Server run on different hosts/containers, so `iat` is routinely a few hundred milliseconds to a few seconds ahead of the Resource Server's clock and the previously-effective leeway of `0` for `iat` produced spurious 401s. `TokenDecoder` now disables ruby-jwt's built-in `iat` check and performs its own `iat` validation that applies the configured `leeway` consistently with `exp` and `nbf`. Behaviour for tokens with `iat` further in the future than `leeway` is unchanged (still rejected with `invalid_token`). Pass `options: { verify_iat: false }` to skip the check entirely.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`iat` claim now honors `leeway`** (`TokenDecoder`): On ruby-jwt 3.x the built-in `Claims::IssuedAt` validator ignores the `leeway` option and raises `JWT::InvalidIatError` whenever `iat` is even a fraction of a second in the future. In typical OIDC deployments the IdP (e.g. Keycloak) and the Resource Server run on different hosts/containers, so `iat` is routinely a few hundred milliseconds to a few seconds ahead of the Resource Server's clock and the previously-effective leeway of `0` for `iat` produced spurious 401s. `TokenDecoder` now disables ruby-jwt's built-in `iat` check and performs its own `iat` validation that applies the configured `leeway` consistently with `exp` and `nbf`. Behaviour for tokens with `iat` further in the future than `leeway` is unchanged (still rejected with `invalid_token`). Pass `options: { verify_iat: false }` to skip the check entirely.
+- **`iat` validation now handles symbol-keyed payloads**: `verify_iat_with_leeway!` looks up both `'iat'` and `:iat`, so callers who request symbol-keyed payloads from `JWT.decode` still get the leeway-aware `iat` check applied.
+
+### Security
+- **Bumped `rack` to `>= 3.2.6` and `json` to `>= 2.19.5`** in `Gemfile.lock` to clear known advisories surfaced by `bundler-audit` (rack request-smuggling and json format-string injection).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.2] - 2026-05-09
+
+### Fixed
+- **`iat` claim now honors `leeway`** (`TokenDecoder`): On ruby-jwt 3.x the
+  built-in `Claims::IssuedAt` validator ignores the `leeway` option and
+  raises `JWT::InvalidIatError` whenever `iat` is even a fraction of a
+  second in the future. In typical OIDC deployments the IdP (e.g. Keycloak)
+  and the Resource Server run on different hosts/containers, so `iat` is
+  routinely a few hundred milliseconds to a few seconds ahead of the
+  Resource Server's clock and the previously-effective leeway of `0` for
+  `iat` produced spurious 401s. `TokenDecoder` now disables ruby-jwt's
+  built-in `iat` check and performs its own `iat` validation that applies
+  the configured `leeway` consistently with `exp` and `nbf`. Behaviour
+  for tokens with `iat` further in the future than `leeway` is unchanged
+  (still rejected with `invalid_token`). Pass
+  `options: { verify_iat: false }` to skip the check entirely.
+
+---
+
 ## [1.0.1] - 2026-02-15
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak (1.0.1)
+    verikloak (1.0.2)
       faraday (>= 2.14.1, < 3.0)
       faraday-retry (>= 2.4.0, < 3.0)
       json (~> 2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     faraday-retry (2.4.0)
       faraday (~> 2.0)
     hashdiff (1.2.1)
-    json (2.18.1)
+    json (2.19.5)
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
@@ -47,7 +47,7 @@ GEM
     prism (1.6.0)
     public_suffix (7.0.2)
     racc (1.8.1)
-    rack (3.2.3)
+    rack (3.2.6)
     rack-test (2.2.0)
       rack (>= 1.3)
     rainbow (3.1.1)

--- a/README.md
+++ b/README.md
@@ -341,7 +341,16 @@ config.middleware.use Verikloak::Middleware,
   because ruby-jwt 3.x's built-in `iat` validator ignores the `leeway`
   option; pass `token_verify_options: { verify_iat: false }` to skip the
   `iat` check entirely.
-- `token_verify_options:` is passed directly to TokenDecoder (and ultimately to `JWT.decode`).
+- `token_verify_options:` is forwarded to `TokenDecoder` (and ultimately
+  to `JWT.decode`), with the following keys handled by Verikloak rather
+  than passed through verbatim:
+  - `:leeway` — Verikloak forwards it to `JWT.decode` so it applies to
+    `exp`/`nbf`, and also uses it for its own `iat` check.
+  - `:verify_iat` — ruby-jwt's built-in `iat` validator is always
+    disabled (it ignores `:leeway` on ruby-jwt 3.x). Setting
+    `verify_iat: false` instead skips Verikloak's own `iat` check;
+    setting `verify_iat: true` (the default) keeps it enabled.
+  All other keys are forwarded to `JWT.decode` as-is.
 - If both are set, `token_verify_options[:leeway]` takes precedence.
 
 ## Performance & Caching

--- a/README.md
+++ b/README.md
@@ -336,7 +336,11 @@ config.middleware.use Verikloak::Middleware,
   }
 ```
 
-- `leeway:` sets the default skew tolerance in seconds.
+- `leeway:` sets the default skew tolerance in seconds. It is applied to
+  `exp`, `nbf`, and `iat`. Verikloak applies leeway to `iat` itself
+  because ruby-jwt 3.x's built-in `iat` validator ignores the `leeway`
+  option; pass `token_verify_options: { verify_iat: false }` to skip the
+  `iat` check entirely.
 - `token_verify_options:` is passed directly to TokenDecoder (and ultimately to `JWT.decode`).
 - If both are set, `token_verify_options[:leeway]` takes precedence.
 

--- a/lib/verikloak/token_decoder.rb
+++ b/lib/verikloak/token_decoder.rb
@@ -8,7 +8,9 @@ module Verikloak
   # This class validates a JWT's signature and standard claims (`iss`, `aud`, `exp`, `nbf`, etc.)
   # using the appropriate RSA public key selected by the JWT's `kid` header.
   # Only `RS256`-signed tokens with RSA JWKs are supported.
-  # It also supports a configurable clock skew (`leeway`) to account for minor time drift.
+  # It also supports a configurable clock skew (`leeway`) to account for minor time drift,
+  # which is applied uniformly to `exp`, `nbf`, and `iat` (Verikloak applies leeway to
+  # `iat` itself because ruby-jwt 3.x's built-in `iat` validator ignores leeway).
   #
   # @example
   #   decoder = Verikloak::TokenDecoder.new(
@@ -41,7 +43,12 @@ module Verikloak
       @leeway   = leeway
       # Normalize and store verification options
       @options  = symbolize_keys(options || {})
-      @options_without_leeway = @options.except(:leeway).freeze
+      # Remove keys we manage ourselves so user-supplied values don't
+      # re-enable ruby-jwt's built-in (broken w.r.t. leeway) iat validator
+      # via the final merge in #jwt_decode_options. The user's intent for
+      # :leeway / :verify_iat is still honoured by reading from @options
+      # directly elsewhere in this class.
+      @options_for_jwt = @options.except(:leeway, :verify_iat).freeze
 
       # Build a kid-indexed hash for O(1) JWK lookup
       @jwk_by_kid = {}
@@ -118,7 +125,41 @@ module Verikloak
     # @return [Hash] Verified claims (payload).
     def decode_with_public_key(token, public_key)
       payload, = JWT.decode(token, public_key, true, jwt_decode_options)
+      verify_iat_with_leeway!(payload)
       payload
+    end
+
+    # Verifies the `iat` (issued-at) claim with the configured leeway tolerance.
+    #
+    # ruby-jwt 3.x's built-in `Claims::IssuedAt` validator does not honor the
+    # `leeway` option; it raises `JWT::InvalidIatError` whenever `iat` is even
+    # a fraction of a second in the future. In OIDC deployments the IdP
+    # (e.g. Keycloak) and the Resource Server typically run on different
+    # hosts/containers with small clock skew, so `iat` is routinely a few
+    # hundred milliseconds to a few seconds in the future relative to the
+    # Resource Server's clock. To provide behaviour consistent with `exp`
+    # and `nbf` (which honor `leeway`), Verikloak performs its own `iat`
+    # check after `JWT.decode` with the configured leeway applied.
+    #
+    # Users may opt out by passing `options: { verify_iat: false }` to the
+    # decoder, in which case this check is skipped entirely.
+    #
+    # @param payload [Hash] Decoded JWT claims.
+    # @return [void]
+    # @raise [TokenDecoderError] code: 'invalid_token' when `iat` is not
+    #   numeric or is further in the future than the allowed leeway.
+    def verify_iat_with_leeway!(payload)
+      return if @options[:verify_iat] == false
+      return unless payload.is_a?(Hash) && payload.key?('iat')
+
+      iat = payload['iat']
+      leeway = @options.key?(:leeway) ? @options[:leeway] : @leeway
+      leeway = leeway.to_f
+
+      return if iat.is_a?(Numeric) && iat.to_f <= Time.now.to_f + leeway
+
+      raise TokenDecoderError.new('Invalid issued-at (iat) claim',
+                                  code: 'invalid_token')
     end
 
     # Returns the verification options passed to JWT.decode.
@@ -129,6 +170,15 @@ module Verikloak
     # - Expiration (`exp`) and not-before (`nbf`) checks
     # - Clock skew tolerance via `leeway`
     #
+    # NOTE: `verify_iat` is intentionally disabled here. ruby-jwt 3.x's
+    # built-in `iat` validator ignores the `leeway` option, which causes
+    # spurious `JWT::InvalidIatError` failures whenever the IdP clock is
+    # even slightly ahead of the Resource Server's clock. Verikloak
+    # re-implements the `iat` check in {#verify_iat_with_leeway!} so the
+    # configured `leeway` is honoured consistently with `exp` and `nbf`.
+    # Users may still opt out entirely by passing
+    # `options: { verify_iat: false }` to the decoder.
+    #
     # @return [Hash]
     def jwt_decode_options
       base = {
@@ -137,15 +187,17 @@ module Verikloak
         verify_iss: true,
         aud: @audience,
         verify_aud: true,
-        verify_iat: true,
+        # See note above: handled by verify_iat_with_leeway! after decode.
+        verify_iat: false,
         verify_expiration: true,
         verify_not_before: true
       }
       # options[:leeway] overrides top-level @leeway if provided
       leeway = @options.key?(:leeway) ? @options[:leeway] : @leeway
       merged = base.merge(leeway: leeway)
-      # Merge remaining options last (excluding :leeway which is already applied)
-      extra = @options_without_leeway
+      # Merge remaining options last (excluding :leeway and :verify_iat,
+      # which Verikloak manages itself — see initializer comment).
+      extra = @options_for_jwt
       merged.merge(extra)
     end
 

--- a/lib/verikloak/token_decoder.rb
+++ b/lib/verikloak/token_decoder.rb
@@ -150,9 +150,15 @@ module Verikloak
     #   numeric or is further in the future than the allowed leeway.
     def verify_iat_with_leeway!(payload)
       return if @options[:verify_iat] == false
-      return unless payload.is_a?(Hash) && payload.key?('iat')
+      return unless payload.is_a?(Hash)
 
-      iat = payload['iat']
+      # Support both string- and symbol-keyed payloads. Callers may pass
+      # `options: { symbolize_names: true }` which causes JWT.decode to
+      # return symbol keys; without indifferent lookup we'd silently
+      # skip iat validation while ruby-jwt's check is disabled.
+      return unless payload.key?('iat') || payload.key?(:iat)
+
+      iat = payload.key?('iat') ? payload['iat'] : payload[:iat]
       leeway = @options.key?(:leeway) ? @options[:leeway] : @leeway
       leeway = leeway.to_f
 

--- a/lib/verikloak/version.rb
+++ b/lib/verikloak/version.rb
@@ -2,5 +2,5 @@
 
 module Verikloak
   # Defines the current version of the Verikloak gem.
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/spec/verikloak/token_decoder_spec.rb
+++ b/spec/verikloak/token_decoder_spec.rb
@@ -168,6 +168,7 @@ RSpec.describe Verikloak::TokenDecoder do
     end
 
     it "raises invalid_token when iat is in the future beyond leeway" do
+      allow(Time).to receive(:now).and_return(Time.at(now))
       token = encode(iat: now + 31) # leeway is 30
       expect { decoder.decode!(token) }.to raise_error(Verikloak::TokenDecoderError) { |e|
         expect(e.code).to eq("invalid_token")

--- a/spec/verikloak/token_decoder_spec.rb
+++ b/spec/verikloak/token_decoder_spec.rb
@@ -197,6 +197,12 @@ RSpec.describe Verikloak::TokenDecoder do
     end
 
     it "applies leeway to iat consistently with exp/nbf (boundary cases)" do
+      # Freeze time so the boundary checks are deterministic regardless
+      # of CI scheduling jitter (the expectation `iat == now + 31` must
+      # always evaluate against the same `Time.now` we used to encode).
+      frozen = Time.at(now)
+      allow(Time).to receive(:now).and_return(frozen)
+
       # Top-level leeway = 30 in subject(:decoder).
       expect(decoder.decode!(encode(iat: now + 15))).to be_a(Hash) # within leeway
       expect(decoder.decode!(encode(iat: now + 30))).to be_a(Hash) # exactly at boundary
@@ -235,6 +241,28 @@ RSpec.describe Verikloak::TokenDecoder do
       )
       token = encode(iat: now + 10)
       expect(opt_decoder.decode!(token)).to be_a(Hash)
+    end
+
+    it "validates iat regardless of whether the payload uses string or symbol keys" do
+      # Some callers (or JWT.decode configurations) may produce payloads
+      # keyed by symbols rather than strings. Our iat check must locate
+      # and validate the iat claim either way.
+      opt_decoder = described_class.new(
+        jwks: jwks, issuer: issuer, audience: audience, leeway: 30
+      )
+      allow(Time).to receive(:now).and_return(Time.at(now))
+
+      string_payload = { "iat" => now + 10 }
+      symbol_payload = { iat: now + 10 }
+      expect { opt_decoder.send(:verify_iat_with_leeway!, string_payload) }.not_to raise_error
+      expect { opt_decoder.send(:verify_iat_with_leeway!, symbol_payload) }.not_to raise_error
+
+      future_string = { "iat" => now + 120 }
+      future_symbol = { iat: now + 120 }
+      expect { opt_decoder.send(:verify_iat_with_leeway!, future_string) }
+        .to raise_error(Verikloak::TokenDecoderError) { |e| expect(e.code).to eq("invalid_token") }
+      expect { opt_decoder.send(:verify_iat_with_leeway!, future_symbol) }
+        .to raise_error(Verikloak::TokenDecoderError) { |e| expect(e.code).to eq("invalid_token") }
     end
   
     it "allows expired token when verify_expiration is disabled via options" do

--- a/spec/verikloak/token_decoder_spec.rb
+++ b/spec/verikloak/token_decoder_spec.rb
@@ -195,6 +195,47 @@ RSpec.describe Verikloak::TokenDecoder do
       token = encode(iat: now + 120) # far in the future
       expect(opt_decoder.decode!(token)).to be_a(Hash)
     end
+
+    it "applies leeway to iat consistently with exp/nbf (boundary cases)" do
+      # Top-level leeway = 30 in subject(:decoder).
+      expect(decoder.decode!(encode(iat: now + 15))).to be_a(Hash) # within leeway
+      expect(decoder.decode!(encode(iat: now + 30))).to be_a(Hash) # exactly at boundary
+      expect { decoder.decode!(encode(iat: now + 31)) }.to raise_error(Verikloak::TokenDecoderError) { |e|
+        expect(e.code).to eq("invalid_token")
+        expect(e.message).to match(/iat/i)
+      }
+    end
+
+    it "rejects non-numeric iat with invalid_token" do
+      # ruby-jwt 3.x rejects non-numeric iat at encode time, so build the
+      # token manually (header.payload.signature, base64url) to bypass it.
+      header  = { kid: "kid-1", alg: "RS256", typ: "JWT" }
+      payload = { iss: issuer, aud: audience, exp: now + 300, nbf: now - 10, iat: "abc" }
+      signing_input = [header, payload].map { |h| JWT::Base64.url_encode(h.to_json) }.join(".")
+      signature = rsa.sign(OpenSSL::Digest::SHA256.new, signing_input)
+      token = "#{signing_input}.#{JWT::Base64.url_encode(signature)}"
+
+      expect { decoder.decode!(token) }.to raise_error(Verikloak::TokenDecoderError) { |e|
+        expect(e.code).to eq("invalid_token")
+        expect(e.message).to match(/iat/i)
+      }
+    end
+
+    it "passes when iat claim is absent" do
+      # Build a payload manually to omit iat entirely.
+      payload = { iss: issuer, aud: audience, exp: now + 300, nbf: now - 10 }
+      token = JWT.encode(payload, rsa, "RS256", { kid: "kid-1", alg: "RS256", typ: "JWT" })
+      expect(decoder.decode!(token)).to be_a(Hash)
+    end
+
+    it "ignores user-supplied verify_iat: true and still applies leeway" do
+      # Without our handling, ruby-jwt 3.x would reject any future iat regardless of leeway.
+      opt_decoder = described_class.new(
+        jwks: jwks, issuer: issuer, audience: audience, leeway: 30, options: { verify_iat: true }
+      )
+      token = encode(iat: now + 10)
+      expect(opt_decoder.decode!(token)).to be_a(Hash)
+    end
   
     it "allows expired token when verify_expiration is disabled via options" do
       opt_decoder = described_class.new(


### PR DESCRIPTION
### Fixed
- **`iat` claim now honors `leeway`** (`TokenDecoder`): On ruby-jwt 3.x the built-in `Claims::IssuedAt` validator ignores the `leeway` option and raises `JWT::InvalidIatError` whenever `iat` is even a fraction of a second in the future. In typical OIDC deployments the IdP (e.g. Keycloak) and the Resource Server run on different hosts/containers, so `iat` is routinely a few hundred milliseconds to a few seconds ahead of the Resource Server's clock and the previously-effective leeway of `0` for `iat` produced spurious 401s. `TokenDecoder` now disables ruby-jwt's built-in `iat` check and performs its own `iat` validation that applies the configured `leeway` consistently with `exp` and `nbf`. Behaviour for tokens with `iat` further in the future than `leeway` is unchanged (still rejected with `invalid_token`). Pass `options: { verify_iat: false }` to skip the check entirely.
- **`iat` validation now handles symbol-keyed payloads**: `verify_iat_with_leeway!` looks up both `'iat'` and `:iat`, so callers who request symbol-keyed payloads from `JWT.decode` still get the leeway-aware `iat` check applied.

### Security
- **Bumped `rack` to `>= 3.2.6` and `json` to `>= 2.19.5`** in `Gemfile.lock` to clear known advisories surfaced by `bundler-audit` (rack request-smuggling and json format-string injection).